### PR TITLE
Allow arbitrary yaml connection files

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,5 +22,6 @@ Imports:
   RSQLite,
   ggplot2,
   yaml,
-  rlang
+  rlang, 
+  fs
 RoxygenNote: 6.0.1

--- a/R/reports.R
+++ b/R/reports.R
@@ -171,8 +171,13 @@ coverage <- function(results){
 
 #' @export
 plot_tests <- function(results){
-  dataset <- results %>%
-    as.data.frame(stringsAsFactors = FALSE) %>%
+  if (is.list(results) & is.null(names(results))) {
+    prep_results <- results %>%
+      map_df(~as.data.frame(.x, stringsAsFactors = FALSE))
+  } else {
+    prep_results <- results %>% as.data.frame(stringsAsFactors = FALSE)
+  }
+  dataset <- prep_results %>%
     mutate(
       result = ifelse(results.failed == 1 | results.error, "Failed", "Passed"),
       test = paste0(results.test, "\n" ,results.context),

--- a/R/reports.R
+++ b/R/reports.R
@@ -171,18 +171,19 @@ coverage <- function(results){
 
 #' @export
 plot_tests <- function(results){
-  results %>%
-    map_df(~as.data.frame(.x,  stringsAsFactors = FALSE)) %>%
+  dataset <- results %>%
+    as.data.frame(stringsAsFactors = FALSE) %>%
     mutate(
       result = ifelse(results.failed == 1 | results.error, "Failed", "Passed"),
       test = paste0(results.test, "\n" ,results.context),
       filler = ""
     ) %>%
-    select(connection, test, result, filler) %>%
-    ggplot() +
-    geom_tile(aes(x = filler, y = test, fill = result), color = "black") +
+    select(connection, test, result, filler, justtest=results.test, context=results.context)
+
+    ggplot(dataset) +
+    geom_tile(aes(x = filler, y = justtest, fill = result), color = "black") +
     scale_fill_discrete(limits = c("Failed", "Passed")) +
-    facet_grid(.~connection) +
+    facet_grid(context~connection, scales = 'free') +
     labs(x = "", y = "")
 }
 

--- a/R/testthat.R
+++ b/R/testthat.R
@@ -116,7 +116,7 @@ testthat_database <- function(datasource, label = NULL, tests = "default") {
 
   # Create a testing function that lives inside the new testthat env
   run_test <- function(verb, vector_expression) {
-    f <- parse_expr(vector_expression)
+    f <- rlang::parse_expr(vector_expression)
 
     if (verb == "summarise") manip <- . %>% summarise(!! f) %>% pull()
     if (verb == "mutate") manip <- . %>% mutate(!! f) %>% pull()

--- a/R/testthat.R
+++ b/R/testthat.R
@@ -131,7 +131,7 @@ testthat_database <- function(datasource, label = NULL, tests = "default") {
     if (verb == "filter") manip <- . %>% filter(!! f) %>% pull()
     if (verb == "group_by") manip <- . %>% group_by(!! f) %>% summarise() %>% pull()
 
-    test_that(paste0(vector_expression), {
+    test_that(paste0(verb,": ",vector_expression), {
       invisible({
         expect_equal(
           manip(local_df),

--- a/R/testthat.R
+++ b/R/testthat.R
@@ -11,13 +11,20 @@ test_databases <- function(datasources = NULL,
         test_single_database(con, tests = tests)
         dbDisconnect(con)
       })
-  } else if (datasources == "config" | datasources == "") {
+  } else if (datasources == "config" |
+             datasources == "" |
+             all(tolower(fs::path_ext(datasources)) %in% c("yml","yaml")) &&
+             all(fs::file_exists(datasources))
+             ) {
+
     # Suppress warnings until config issue is resolved
     # https://github.com/rstudio/config/issues/12
     if (datasources == "") {
       file_path = default_config_path()
-    } else if (fs::path_ext(datasources) %in% c("yml", "yaml")
-               && fs::file_exists(datasources)) {
+    } else if (
+      all(tolower(fs::path_ext(datasources)) %in% c("yml", "yaml"))
+      && all(fs::file_exists(datasources))
+      ) {
       file_path = datasources
     } else {
       file_path = NULL

--- a/R/testthat.R
+++ b/R/testthat.R
@@ -17,6 +17,11 @@ test_databases <- function(datasources = NULL, tests = "default"){
     # https://github.com/rstudio/config/issues/12
     if(datasources == ""){
       file_path = default_config_path()
+    } else if (
+      fs::path_ext(datasources) %in% c("yml","yaml")
+      && fs::file_exists(datasources)
+      ) {
+      file_path = datasources
     } else {
       file_path = NULL
     }

--- a/R/testthat.R
+++ b/R/testthat.R
@@ -106,7 +106,14 @@ testthat_database <- function(datasource, label = NULL, tests = "default") {
 
   # Address test data
   if(isS4(datasource)){
-    remote_df <- copy_to(datasource, testdata)
+    remote_df <- copy_to(datasource, testdata
+                         , name=tolower(
+                           paste(
+                             sample(LETTERS, size=20, replace=TRUE)
+                             ,collapse='')
+                           )
+                         )
+
     local_df  <- testdata
   }
   if("tbl_sql" %in% class(datasource)){

--- a/R/testthat.R
+++ b/R/testthat.R
@@ -17,8 +17,6 @@ test_databases <- function(datasources = NULL,
              all(fs::file_exists(datasources)))
              ) {
 
-    # Suppress warnings until config issue is resolved
-    # https://github.com/rstudio/config/issues/12
     if (datasources == "") {
       file_path = default_config_path()
     } else if (
@@ -32,6 +30,9 @@ test_databases <- function(datasources = NULL,
 
     if (length(file_path) > 1)
       stop(sprintf("Multiple datasources are not currently supported"))
+
+    # Suppress warnings until config issue is resolved
+    # https://github.com/rstudio/config/issues/12
     suppressWarnings(cons <- config::get(file = file_path))
 
     names(cons) %>%

--- a/R/testthat.R
+++ b/R/testthat.R
@@ -29,6 +29,9 @@ test_databases <- function(datasources = NULL,
     } else {
       file_path = NULL
     }
+
+    if (length(file_path) > 1)
+      stop(sprintf("Multiple datasources are not currently supported"))
     suppressWarnings(cons <- config::get(file = file_path))
 
     names(cons) %>%

--- a/R/testthat.R
+++ b/R/testthat.R
@@ -13,8 +13,8 @@ test_databases <- function(datasources = NULL,
       })
   } else if (datasources == "config" |
              datasources == "" |
-             all(tolower(fs::path_ext(datasources)) %in% c("yml","yaml")) &&
-             all(fs::file_exists(datasources))
+             (all(tolower(fs::path_ext(datasources)) %in% c("yml","yaml")) &&
+             all(fs::file_exists(datasources)))
              ) {
 
     # Suppress warnings until config issue is resolved

--- a/R/testthat.R
+++ b/R/testthat.R
@@ -149,14 +149,14 @@ testthat_database <- function(datasource, label = NULL, tests = "default") {
     "group_by",
     "arrange"
   )
-  verbs %>%
+
+  tests %>%
     map(~{
-      verb <- .x
-      context(verb)
-      tests %>%
+      curr_test <- .x
+      context(names(curr_test))
+      curr_test %>%
         purrr::flatten() %>%
-        map(~.x[verb]) %>%
-        purrr::flatten() %>%
-        map(~run_test(verb, .x))
+        map2(names(.)
+             , ~run_test(.y, .x))
     })
 }

--- a/R/testthat.R
+++ b/R/testthat.R
@@ -69,7 +69,7 @@ test_single_database <- function(datasource, label = NULL, tests = "default") {
                      , testthat::ListReporter$new())
   )
 
-  r <- with_reporter(
+  r <- testthat::with_reporter(
     reporter,
     testthat_database(
       datasource = datasource,

--- a/R/testthat.R
+++ b/R/testthat.R
@@ -10,9 +10,7 @@ test_databases <- function(datasources = NULL, tests = "default"){
         test_single_database(con, tests = tests)
         dbDisconnect(con)
       })
-    }
-
-  if(datasources == "config" | datasources == ""){
+    } else if(datasources == "config" | datasources == ""){
     # Suppress warnings until config issue is resolved
     # https://github.com/rstudio/config/issues/12
     if(datasources == ""){
@@ -36,7 +34,15 @@ test_databases <- function(datasources = NULL, tests = "default"){
         tests
       })
 
+    } else {
+    stop(
+      paste0("Unrecognized value for `datasources`: '%s'"
+             ,", please use either an existing config YAML file, 'config', 'dsn' or NULL"
+             ) %>%
+        sprintf(datasources)
+    )
   }
+
 }
 
 rm_decoys <- function(x) {

--- a/R/testthat.R
+++ b/R/testthat.R
@@ -65,7 +65,8 @@ rm_decoys <- function(x) {
 test_single_database <- function(datasource, label = NULL, tests = "default") {
 
   reporter <- testthat::MultiReporter$new(
-    reporters = list(MinimalReporter$new(), ListReporter$new())
+    reporters = list(testthat::MinimalReporter$new()
+                     , testthat::ListReporter$new())
   )
 
   r <- with_reporter(

--- a/R/testthat.R
+++ b/R/testthat.R
@@ -7,7 +7,7 @@ test_databases <- function(datasources = NULL,
   if (datasources == "dsn") {
     odbc::odbcListDataSources()$name %>%
       map( ~ {
-        con <- dbConnect(odbc::odbc(), dsn = .x)
+        con <- DBI::dbConnect(odbc::odbc(), dsn = .x)
         test_single_database(con, tests = tests)
         dbDisconnect(con)
       })
@@ -64,7 +64,7 @@ rm_decoys <- function(x) {
 #' @export
 test_single_database <- function(datasource, label = NULL, tests = "default") {
 
-  reporter <- MultiReporter$new(
+  reporter <- testthat::MultiReporter$new(
     reporters = list(MinimalReporter$new(), ListReporter$new())
   )
 
@@ -97,9 +97,9 @@ testthat_database <- function(datasource, label = NULL, tests = "default") {
 
   # Load test scripts from YAML format
   if (tests == "default") {
-    tests <- read_yaml(default_tests_path())
+    tests <- yaml::read_yaml(default_tests_path())
   } else {
-    if (class(tests) == "character") tests <- read_yaml(tests)
+    if (class(tests) == "character") tests <- yaml::read_yaml(tests)
   }
   if (class(tests) != "list") error("Tests need to be in YAML format")
 

--- a/R/testthat.R
+++ b/R/testthat.R
@@ -5,7 +5,7 @@ test_databases <- function(datasources = NULL,
     datasources <- ""
 
   if (datasources == "dsn") {
-    odbc::odbcListDataSources() %>%
+    odbc::odbcListDataSources()$name %>%
       map( ~ {
         con <- dbConnect(odbc::odbc(), dsn = .x)
         test_single_database(con, tests = tests)

--- a/R/testthat.R
+++ b/R/testthat.R
@@ -125,7 +125,7 @@ testthat_database <- function(datasource, label = NULL, tests = "default") {
   run_test <- function(verb, vector_expression) {
     f <- rlang::parse_expr(vector_expression)
 
-    if (verb == "summarise") manip <- . %>% summarise(!! f) %>% pull()
+    if (verb %in% c("summarise","summarize")) manip <- . %>% summarise(!! f) %>% pull()
     if (verb == "mutate") manip <- . %>% mutate(!! f) %>% pull()
     if (verb == "arrange") manip <- . %>% arrange(!! f) %>% pull()
     if (verb == "filter") manip <- . %>% filter(!! f) %>% pull()

--- a/inst/extdata/config.yml
+++ b/inst/extdata/config.yml
@@ -1,7 +1,7 @@
 default:
   sqlite:
-     drv: !expr RSQLite::SQLite()
-     path: ":memory:"
+    drv: !expr RSQLite::SQLite()
+    path: ":memory:"
   sqlite2:
-   drv: !expr RSQLite::SQLite()
-   path: ":memory:"
+    drv: !expr RSQLite::SQLite()
+    path: ":memory:"

--- a/inst/extdata/tests.yml
+++ b/inst/extdata/tests.yml
@@ -1,6 +1,53 @@
-- test:
+- round:
     mutate: round(fld_double, 0)
     filter: round(fld_double, 0) > 1
     summarise: sum(round(fld_double, 0), na.rm = TRUE)
     group_by: round(fld_double, 0)
     arrange: round(fld_double, 0)
+- add:
+    mutate: fld_double + fld_integer
+    filter: fld_double + fld_integer < 10
+    summarise: sum(fld_double + fld_integer, na.rm=TRUE)
+    group_by: fld_double + fld_integer
+    arrange: fld_double + fld_integer
+- subtract:
+    mutate: fld_double - fld_integer
+    filter: fld_double - fld_integer < 1
+    summarise: sum(fld_double - fld_integer, na.rm=TRUE)
+    group_by: fld_double - fld_integer
+    arrange: fld_double - fld_integer
+- multiply:
+    mutate: fld_double * fld_integer
+    filter: fld_double * fld_integer < 10
+    summarise: sum(fld_double * fld_integer, na.rm=TRUE)
+    group_by: fld_double * fld_integer
+    arrange: fld_double * fld_integer
+- divide:
+    mutate: fld_double / fld_integer
+    filter: fld_double / fld_integer < 10
+    summarise: sum(fld_double / fld_integer, na.rm=TRUE)
+    group_by: fld_double / fld_integer
+    arrange: fld_double / fld_integer
+- power:
+    mutate: fld_double ^ fld_integer
+    filter: fld_double ^ fld_integer < 10
+    summarise: sum(fld_double ^ fld_integer, na.rm=TRUE)
+    group_by: fld_double ^ fld_integer
+    arrange: fld_double ^ fld_integer
+- remainder:
+    mutate: (2 * fld_integer) %% (fld_integer + 1)
+    filter: (2 * fld_integer) %% (fld_integer + 1) < 5
+    summarise: sum((2 * fld_integer) %% (fld_integer + 1), na.rm=TRUE)
+    group_by: (2 * fld_integer) %% (fld_integer + 1)
+    arrange: (2 * fld_integer) %% (fld_integer + 1)
+- logical_noteq:
+    mutate: fld_integer != fld_double
+    filter: fld_integer != fld_double
+    summarise: sum(fld_integer != fld_double, na.rm=TRUE)
+    group_by: fld_integer != fld_double
+    mutate: fld_integer != fld_integer
+    filter: fld_integer != fld_integer
+    summarise: sum(fld_integer != fld_integer, na.rm=TRUE)
+    group_by: fld_integer != fld_integer
+
+

--- a/inst/extdata/tests.yml
+++ b/inst/extdata/tests.yml
@@ -40,12 +40,12 @@
     summarise: sum((2 * fld_integer) %% (fld_integer + 1), na.rm=TRUE)
     group_by: (2 * fld_integer) %% (fld_integer + 1)
     arrange: (2 * fld_integer) %% (fld_integer + 1)
-- logical_noteq:
+- bool_neq:
     mutate: fld_integer != fld_double
     filter: fld_integer != fld_double
     summarise: sum(fld_integer != fld_double, na.rm=TRUE)
     group_by: fld_integer != fld_double
-- logical_noteq_diff:
+- bool_neq_same:
     mutate: fld_integer != fld_integer
     filter: fld_integer != fld_integer
     summarise: sum(fld_integer != fld_integer, na.rm=TRUE)

--- a/inst/extdata/tests.yml
+++ b/inst/extdata/tests.yml
@@ -45,6 +45,7 @@
     filter: fld_integer != fld_double
     summarise: sum(fld_integer != fld_double, na.rm=TRUE)
     group_by: fld_integer != fld_double
+- logical_noteq_diff:
     mutate: fld_integer != fld_integer
     filter: fld_integer != fld_integer
     summarise: sum(fld_integer != fld_integer, na.rm=TRUE)


### PR DESCRIPTION
Main features / functionality added:

- allow specifying arbitrary YAML connection files in `test_databases`
- fix some package deps / namespace issues
- change `plot_tests` to allow for working with `test_single_database`
- randomize table name on create (see #5 for more discussion on where to go next)
- allow `summarize` as variant of `summarise`
- iterate over test headers in the yaml _and_ verbs, while preserving the info in test naming
- alter the plot output a smidge (see below)

![image](https://user-images.githubusercontent.com/23075542/37430432-7aae6aee-27a8-11e8-9874-1644c007c24e.png)
